### PR TITLE
Fix demjson 2to3 install failure

### DIFF
--- a/consullock/cli.py
+++ b/consullock/cli.py
@@ -10,7 +10,7 @@ from enum import Enum, unique
 from os.path import normpath
 from typing import List, Any, Optional, Dict
 
-import demjson as demjson
+import demjson3 as demjson
 
 from consullock._logging import create_logger
 from consullock.configuration import DEFAULT_SESSION_TTL, DEFAULT_LOG_VERBOSITY, DEFAULT_NON_BLOCKING, \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-consul>=0.7.2
 timeout-decorator>=0.4.0
 hgijson>=1.5.0
-demjson>=2.2.4
+demjson3>=3.0.5
 munch>=2.2.0


### PR DESCRIPTION
Use the new demjson3 library to fix consullock install failure.
demjson is no longer possible to install on python3 when
setuptools >58.0.0 is used.

See this issue for more details:
https://github.com/dmeranda/demjson/issues/40

Fixes #4